### PR TITLE
typo in polygon (with holes) heading

### DIFF
--- a/data-organization/Annotation-JSON-format/04_Supervisely_Format_objects.md
+++ b/data-organization/Annotation-JSON-format/04_Supervisely_Format_objects.md
@@ -177,7 +177,7 @@ Fields definitions:
 - `exterior` - list of points [point1, point2, point3, etc ...] where each point is a list of two numbers (coordinates) [col, row]
 - `interior` - list of elements with the same structure as the "exterior" field. In other words, this is the list of polygons that define object holes. For polygons without holes in them, this field is empty
 
-## Polygon (without holes)
+## Polygon (with holes)
 
 Example:
 


### PR DESCRIPTION
Originally the heading was polygon (without holes), but the heading must be polygon (with holes). Since polygon (without holes) already exist above.